### PR TITLE
Deploy Edge Agents to edge clusters via flux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+node_modules
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
 
-version?=${pkgver}
+version?=v${pkgver}
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-edge-deployment

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,13 @@ endif
 
 all: build push
 
-.PHONY: all build push check-committed
+.PHONY: all build push check-committed amend
 
 check-committed:
 	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
+
+amend:
+	git commit -a -C HEAD --amend
 
 build: check-committed
 	docker build -t "${tag}" ${build_args} .

--- a/bin/convert-dumps.js
+++ b/bin/convert-dumps.js
@@ -8,8 +8,9 @@ import yaml from "yaml";
 
 import { UUIDs } from "@amrc-factoryplus/utilities";
 import { Git, Edge } from "../lib/uuids.js";
+import { ACS } from "../dumps/acs.js";
 
-const UUID_SOURCES = { FP: UUIDs, G: Git, E: Edge };
+const UUID_SOURCES = { FP: UUIDs, G: Git, E: Edge, A: ACS };
 const DUMPS = "dumps";
 
 function resolve (str) {

--- a/bin/edge-deployment.js
+++ b/bin/edge-deployment.js
@@ -9,7 +9,8 @@
 import { ServiceClient, WebAPI } from "@amrc-factoryplus/utilities";
 
 import { GIT_VERSION } from "../lib/git-version.js";
-import { EdgeDeploy } from "../lib/edge-deploy.js";
+import { EdgeDeployAPI } from "../lib/edge-deploy-api.js";
+import { Reconciler } from "../lib/reconciler.js";
 import { Edge } from "../lib/uuids.js";
 
 const fplus = await new ServiceClient({
@@ -19,7 +20,11 @@ const fplus = await new ServiceClient({
     git_email:          process.env.GIT_EMAIL,
 }).init();
 
-const edge = await new EdgeDeploy({
+const recon = await new Reconciler({
+    fplus,
+}).init();
+
+const edge = await new EdgeDeployAPI({
     fplus:      fplus,
     realm:      process.env.REALM,
     http_url:   process.env.HTTP_API_URL,

--- a/dumps/acs-configdb.yaml
+++ b/dumps/acs-configdb.yaml
@@ -1,0 +1,44 @@
+service: !u FP.Service.ConfigDB
+version: 1
+classes:
+  - !u ACS.Class.EdgeCluster
+objects:
+  !u ACS.Class.Role:
+    - !u ACS.Role.EdgeFlux
+  !u ACS.Class.ServiceAccount:
+    - !u ACS.Account.EDO
+  !u E.Class.Template:
+    - !u ACS.EdgeTemplate.CellGateway
+configs:
+  !u FP.App.Info:
+    !u ACS.Class.EdgeCluster: { name: "Edge cluster account" }
+    !u ACS.Role.EdgeFlux: { name: "Edge flux" }
+    !u ACS.Account.EDO: { name: "Edge Deployment Operator" }
+    !u ACS.EdgeTemplate.CellGateway: { name: "Cell Gateway" }
+  !u E.App.Template
+    !u ACS.EdgeTemplate.CellGateway:
+      {
+          "flux": {
+              "name": "Edge flux: %n",
+              "class": "97756c9a-38e6-4238-b78c-3df6f227a6c9",
+              "groups": [
+                  "34ee0e7f-8c9c-4f6d-aad7-4ed700bc77da"
+              ],
+              "username": "op1flux/%n"
+          },
+          "name": "cell-gateway",
+          "cluster": {
+              "namespace": "fplus-edge"
+          },
+          "repository": {
+              "group": "cluster",
+              "links": {
+                  "8a3c0860-9e41-48b8-b02f-780a0e582be6": {
+                      "branch": "main",
+                      "interval": "3h0m0s"
+                  }
+              },
+              "branch": "main",
+              "interval": "5m0s"
+          }
+      }

--- a/dumps/acs.js
+++ b/dumps/acs.js
@@ -1,0 +1,19 @@
+export ACS = {
+    Class: {
+        EdgeCluster:    "97756c9a-38e6-4238-b78c-3df6f227a6c9",
+        Role:           "1c567e3c-5519-4418-8682-6086f22fbc13",
+        ServiceAccount: "e463b4ae-a322-46cc-8976-4ba76838e908",
+    },
+
+    Role: {
+        EdgeFlux:       "34ee0e7f-8c9c-4f6d-aad7-4ed700bc77da",
+    },
+
+    Account: {
+        EDO:            "127cde3c-773a-4f61-b0ba-7412a2695253",
+    },
+
+    EdgeTemplate: {
+        CellGateway:    "71648ac2-f2a6-4777-92ac-f7852be68efc",
+    }
+}

--- a/dumps/edge-deploy-configdb.json
+++ b/dumps/edge-deploy-configdb.json
@@ -76,20 +76,55 @@
         "title": "Edge cluster configuration",
         "type": "object",
         "required": [
-          "namespace"
+          "name",
+          "namespace",
+          "template"
         ],
         "properties": {
-          "namespace": {
-            "description": "The k8s namespace to deploy to.",
-            "type": "string"
-          },
           "flux": {
             "description": "The URL of the Git repo driving this cluster.",
             "type": "string"
           },
+          "hosts": {
+            "description": "The hosts available in this cluster.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "hostname"
+              ],
+              "properties": {
+                "hostname": {
+                  "description": "The hostname of the host.",
+                  "type": "string"
+                },
+                "arch": {
+                  "description": "A string describing the host CPU architecture.",
+                  "type": "string"
+                },
+                "os": {
+                  "description": "A string describing the host OS.",
+                  "type": "string"
+                }
+              }
+            }
+          },
           "kubeseal_cert": {
             "description": "The PEM-encoded X509 certificate used by the sealed-secrets operator on the edge cluster.\n",
             "type": "string"
+          },
+          "name": {
+            "description": "The name of the cluster.",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "The k8s namespace to deploy to.",
+            "type": "string"
+          },
+          "template": {
+            "description": "The template UUID we are deployed from.",
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/dumps/edge-deploy-configdb.yaml
+++ b/dumps/edge-deploy-configdb.yaml
@@ -48,19 +48,43 @@ configs:
     !u E.App.Cluster:
       title: Edge cluster configuration
       type: object
-      required: [namespace]
+      required: [name, namespace, template]
       properties:
-        namespace:
-          description: The k8s namespace to deploy to.
-          type: string
         flux:
           description: The URL of the Git repo driving this cluster.
           type: string
+        hosts:
+          description: The hosts available in this cluster.
+          type: array
+          items:
+            type: object
+            required: [hostname]
+            properties:
+              hostname:
+                description: The hostname of the host.
+                type: string
+              arch:
+                description: A string describing the host CPU architecture.
+                type: string
+              os:
+                description: A string describing the host OS.
+                type: string
         kubeseal_cert:
           description: >
             The PEM-encoded X509 certificate used by the
             sealed-secrets operator on the edge cluster.
           type: string
+        name:
+          description: The name of the cluster.
+          type: string
+        namespace:
+          description: The k8s namespace to deploy to.
+          type: string
+        template:
+          description: The template UUID we are deployed from.
+          type: string
+          format: uuid
+
     !u E.App.Template:
       title: Edge cluster template
       description: >

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -112,16 +112,21 @@ export class Checkout {
         if (args.length)
             message = util.format(message, ...args);
 
+
+        const sts = await git.statusMatrix(this.gitopts);
+        if (!sts.some(st => st[2] != 1)) {
+            this.log("No changes in %s, skipping commit", this.dir);
+            return;
+        }
+
         this.log("Committing in %s: %s", this.dir, message);
-        await git.add({ ...this.gitopts, filepath: "." });
-        /* git.add doesn't remove files deleted from the wd */
-        await git.listFiles(this.gitopts)
-            .then(files => Promise.all(files.map(f => 
-                git.status({ ...this.gitopts, filepath: f })
-                    .then(s => s == "*deleted" ? f : null))))
-            .then(fs => fs.filter(f => f != null))
-            .then(fs => Promise.all(fs.map(f => 
-                git.remove({ ...this.gitopts, filepath: f }))));
+        await git.add({ 
+            ...this.gitopts, 
+            filepath: sts.filter(st => st[2] == 2).map(st => st[0]),
+        });
+        await Promise.all(
+            sts.filter(st => st[2] == 0)
+                .map(st => git.remove({ ...this.gitopts, filepath: st[0] })));
 
         const sha = await git.commit({ ...this.gitopts, message });
         this.log("Committed: %s", sha);
@@ -133,7 +138,7 @@ export class Checkout {
 
         this.log("Pushing to %s", this.url);
         const res = await git.push({ ...this.gitopts, url: this.url });
-        this.log("Pushed: %o", res);
+        this.log("Pushed: %o", res.refs);
         await this.dispose();
     }
 

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -16,7 +16,7 @@ import yaml from "yaml";
 import { Debug, UUIDs } from "@amrc-factoryplus/utilities";
 
 import { Git } from "./uuids.js";
-import * as manifests from "./manifests.js";
+import * as tmpl from "./templates.js";
 
 const debug = new Debug();
 
@@ -203,5 +203,13 @@ export class Checkout {
         return files
             .filter(f => f.endsWith(".yaml"))
             .map(f => [namespace, kind, f.slice(0, -5)]);
+    }
+
+    /* Return an absolute path for manifest files managed by a
+     * particular subsystem (e.g. sealed secrets). Currently the cluster
+     * is ignored but it might be used in future with a multi-cluster
+     * repo structure. */
+    path_for (cluster, subsys, ...paths) {
+        return path.join(this.dir, "edo", subsys, ...paths);
     }
 }

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -167,8 +167,8 @@ export class Clusters {
             usage:          "edge-flux",
             namespace:      FLUX.ns,
             principal:      spec.principal,
-            type:           "Password",
-            secret:         FLUX.secret,
+            type:           FLUX.keytype,
+            secret:         `${FLUX.secret}/${FLUX.secretkey}`,
             cluster:        spec.uuid,
         });
     }

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -11,8 +11,8 @@ import { Debug, UUIDs }         from "@amrc-factoryplus/utilities";
 import { Checkout }             from "./checkout.js";
 import { KrbKeys }              from "./krbkeys.js";
 import { write_sealed_secret }  from "./kubeseal.js";
-import * as manifests           from "./manifests.js";
-import { FLUX }                 from "./manifests.js";
+import * as tmpl                from "./templates.js";
+import { FLUX }                 from "./templates.js";
 import { Git, Edge }            from "./uuids.js";
 
 const debug = new Debug();
@@ -179,7 +179,7 @@ export class Clusters {
             fplus:  this.fplus, 
             url:    spec.flux,
         });
-        await co.write_file("README.md", manifests.README);
+        await co.write_file("README.md", tmpl.README);
         await co.commit("Add README.");
         await this.write_username_secret(co, spec);
         await this.setup_repo_links(co, spec);
@@ -210,8 +210,8 @@ export class Clusters {
         const url = new URL(`git/${repo}`, git_base).toString();
 
         this.log("Adding source %s", url);
-        await co.write_manifest(manifests.git_repo(name, url, spec));
-        await co.write_manifest(manifests.flux_kust(name, spec));
+        await co.write_manifest(tmpl.git_repo(name, url, spec));
+        await co.write_manifest(tmpl.flux_kust(name, spec));
     }
 
     async setup_repo_links (co, spec) {
@@ -229,7 +229,7 @@ export class Clusters {
     async create_namespace (co, spec) {
         const { namespace } = spec.template.cluster;
 
-        await co.write_manifest(manifests.namespace(namespace));
+        await co.write_manifest(tmpl.namespace(namespace));
         await co.commit("Written namespace manifest.");
     }
 

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -47,7 +47,7 @@ export class Clusters {
         await this.create_cluster_objects(spec);
         await this.create_flux_user(spec);
         await this.populate_cluster_repo(spec);
-        await this.krbkeys.create_krbkey(spec);
+        await this.create_krbkey(spec);
 
         return [201, { uuid: spec.uuid, flux: spec.flux }];
     }
@@ -151,6 +151,7 @@ export class Clusters {
         const princ = await auth.create_principal(
             flux.class, spec.principal, name);
         this.log("Created Flux principal %s", princ);
+        spec.flux_uuid = princ;
 
         this.log("Granting %s pull access to %s", princ, spec.repo_uuid);
         await auth.add_ace(princ, Git.Perm.Pull, spec.repo_uuid);
@@ -158,6 +159,18 @@ export class Clusters {
             this.log("Adding %s to auth group %s", princ, group);
             await auth.add_to_group(group, princ);
         }
+    }
+
+    create_krbkey (spec) {
+        return this.krbkeys.sync_krbkey({
+            owner:          spec.flux_uuid,
+            usage:          "edge-flux",
+            namespace:      FLUX.ns,
+            principal:      spec.principal,
+            type:           "Password",
+            secret:         FLUX.secret,
+            cluster:        spec.uuid,
+        });
     }
 
     async populate_cluster_repo (spec) {

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -71,6 +71,7 @@ export class Clusters {
             query:  { name: spec.template },
         });
         spec.template = await cdb.get_config(Edge.App.Template, uuid);
+        spec.template.uuid = uuid;
         this.log("Found template %s: %o", uuid, spec.template);
     }
 
@@ -130,7 +131,9 @@ export class Clusters {
 
         await cdb.put_config(UUIDs.App.Info, uuid, { name });
         await cdb.put_config(Edge.App.Cluster, uuid, {
-            flux, namespace, kubeseal_cert,
+            flux, name, namespace, kubeseal_cert,
+            template:   spec.template.uuid,
+            hosts:      [ { hostname: name } ],
         });
 
         spec.uuid = uuid;

--- a/lib/edge-deploy-api.js
+++ b/lib/edge-deploy-api.js
@@ -15,7 +15,7 @@ import { Edge }             from "./uuids.js";
 
 const debug = new Debug();
 
-export class EdgeDeploy {
+export class EdgeDeployAPI {
     constructor (opts) {
         this.fplus      = opts.fplus;
         this.http_url   = opts.http_url;

--- a/lib/krbkeys.js
+++ b/lib/krbkeys.js
@@ -24,7 +24,7 @@ export class KrbKeys {
     }
 
     async sync_krbkey (spec) {
-        this.log("Creating KerberosKey for %s", principal);
+        this.log("Creating KerberosKey for %s", spec.principal);
         const krb = krb_key({
             ...spec,
             local_namespace: this.namespace,

--- a/lib/krbkeys.js
+++ b/lib/krbkeys.js
@@ -8,7 +8,7 @@ import k8s          from "@kubernetes/client-node";
 
 import { Debug }    from "@amrc-factoryplus/utilities";
 
-import { KRB, FLUX, flux_krb_key }  from "./manifests.js";
+import { KRB, FLUX, krb_key }  from "./manifests.js";
 
 const debug = new Debug();
 
@@ -23,11 +23,12 @@ export class KrbKeys {
         this.namespace = kc.getContextObject(kc.currentContext).namespace;
     }
 
-    async create_krbkey (spec) {
-        const { uuid, principal } = spec;
-
+    async sync_krbkey (spec) {
         this.log("Creating KerberosKey for %s", principal);
-        const krb = flux_krb_key(this.namespace, principal, uuid);
+        const krb = krb_key({
+            ...spec,
+            local_namespace: this.namespace,
+        });
         this.log("Built KrbKey object: %o", krb);
 
         const api = this.kc.makeApiClient(k8s.CustomObjectsApi);

--- a/lib/krbkeys.js
+++ b/lib/krbkeys.js
@@ -8,7 +8,7 @@ import k8s          from "@kubernetes/client-node";
 
 import { Debug }    from "@amrc-factoryplus/utilities";
 
-import { KRB, FLUX, krb_key }  from "./manifests.js";
+import { KRB, FLUX, krb_key }  from "./templates.js";
 
 const debug = new Debug();
 

--- a/lib/kubeseal.js
+++ b/lib/kubeseal.js
@@ -10,7 +10,7 @@ import fs_p from "fs/promises";
 import concat_stream from "concat-stream";
 import tmpfile from "tmp-promise";
 
-import * as manifests from "./manifests.js";
+import * as tmpl from "./templates.js";
 
 export async function write_sealed_secret (opts) {
     const { checkout: co, namespace, name, key } = opts;
@@ -19,7 +19,7 @@ export async function write_sealed_secret (opts) {
     opts.log("Got sealed data: %s", sealed);
 
     const obj = await co.read_manifest(namespace, "SealedSecret", name) ??
-        manifests.sealed_secret(namespace, name);
+        tmpl.sealed_secret(namespace, name);
     obj.spec.encryptedData[key] = sealed;
     await co.write_manifest(obj);
     await co.commit("Updated sealed secret %s/%s/%s.", 

--- a/lib/manifests.js
+++ b/lib/manifests.js
@@ -1,150 +1,57 @@
 /*
  * Factory+ / AMRC Connectivity Stack (ACS) Edge Deployment operator
- * Manifest creation functions
+ * YAML handling
  * Copyright 2023 AMRC
  */
 
-export const README = `
-This repo is managed by the Edge Deployment Operator.
-As such some conventions need to be observed.
+import fs from "fs";
+import fs_p from "fs/promises";
+import path from "path";
+import util from "util";
 
-* All manifests must be 1-per-file.
-* All manifests must be YAML, but any comments or formatting are likely
-    to be removed by the operator.
-* Namespaced objects go in \`NAMESPACE/KIND/NAME.yaml\`,
-    e.g. \`fplus-edge/Deployment/edge-agent.yaml\`.
-* Cluster-wide object go in \`_cluster/KIND/NAME.yaml\`.
-`;
+import yaml from "yaml";
 
-const FPLUS = "factoryplus.app.amrc.co.uk";
-export const EDO = `edo.${FPLUS}`;
-
-export const LABELS = {
-    managed_by: `app.kubernetes.io/managed-by`,
-    key_owner:  `${EDO}/key-owner`,
-    key_usage:  `${EDO}/key-usage`,
-};
-
-/* The namespace here needs to be kept in sync with the flux system as
- * installed by the shared/flux-system repo. */
-export const FLUX = {
-    ns:         "flux-system",
-    secret:     "op1flux-secrets",
-    secretkey:  "password",
-    keytype:    "Password",
-    username:   "op1flux/%s",
-    branch:     "main",
-};
-
-export const KRB = {
-    group:      FPLUS,
-    version:    "v1",
-    kind:       "KerberosKey",
-    plural:     "kerberos-keys",
-};
-
-/* Manifest to be teleported via flux should not have LABELS.managed_by
- * as they are not being actively managed on the target cluster. */
-
-export function git_repo (name, url, spec) {
-    return {
-        apiVersion: "source.toolkit.fluxcd.io/v1",
-        kind: "GitRepository",
-        metadata: { namespace: FLUX.ns, name },
-        spec: {
-          interval: spec.interval,
-          ref: { branch: spec.branch },
-          secretRef: { name: FLUX.secret },
-          url,
-    }, };
+async function _handle_enoent (file, cb) {
+    try {
+        return await cb(file);
+    }
+    catch (e) {
+        if (e.code == "ENOENT")
+            return;
+        throw e;
+    }
 }
 
-export function flux_kust (name, spec) {
-    return {
-        apiVersion: "kustomize.toolkit.fluxcd.io/v1",
-        kind: "Kustomization",
-        metadata: { namespace: FLUX.ns, name },
-        spec: {
-            interval: spec.interval,
-            path: "./",
-            prune: true,
-            sourceRef: {
-                kind: "GitRepository",
-                name: name,
-    }, }, };
+function read_file (file) {
+    return _handle_enoent(file, f => fs_p.readFile(f, "utf-8"));
 }
 
-export function flux_helm (spec) {
-    return {
-        apiVersion: "helm.toolkit.fluxcd.io/v2beta1",
-        kind: "HelmRelease",
-        metadata: {
-            namespace: FLUX.ns,
-            name: `${spec.chart}-${spec.uuid}`,
-        },
-        spec: {
-            chart: {
-                spec: {
-                    sourceRef: {
-                        namespace: FLUX.ns,
-                        kind: "GitRepository",
-                        name: spec.repo,
-                    },
-                    chart: "edge-agent",
-                    reconcileStrategy: "Revision",
-                },
-            },
-            interval: "3m0s",
-            values: spec.values,
-        },
-    };
+async function write_file (file, content) {
+    const abs = path.join(this.dir, file);
+    await fs_p.mkdir(path.dirname(abs), { recursive: true });
+    await fs_p.writeFile(abs, content);
 }
 
-export function sealed_secret (namespace, name) {
-    return {
-        apiVersion: "bitnami.com/v1alpha1",
-        kind: "SealedSecret",
-        metadata: { namespace, name },
-        spec: {
-            encryptedData: {},
-            template: {
-                data: null,
-                metadata: { namespace, name },
-                type: "Opaque",
-    }, }, };
+function unlink_file (file) {
+    return _handle_enoent(file, f => fs_p.unlink(f) ?? true);
 }
 
-export function namespace (name) {
-    return {
-        apiVersion: "v1",
-        kind: "Namespace",
-        metadata: { name },
-    };
+/* Path must be absolute */
+export async function read (file) {
+    const content = await read_file(file);
+    if (content == undefined) return;
+
+    const docs = yaml.parseAllDocuments(content);
+    if (docs.some(d => d.errors.length > 0)) {
+        const rel = path.relative(this.dir, file);
+        throw `Bad YAML in '${rel}' in repo '${this.url}'`;
+    }
+
+    return docs.map(d => d.toJS());
 }
 
-/* Manifests to be installed locally should use LABELS.managed_by. */
-
-export function krb_key (spec) {
-    const kname = `edo.${spec.usage}.${spec.owner}`;
-    return {
-        apiVersion: `${KRB.group}/${KRB.version}`,
-        kind: KRB.kind,
-        metadata: {
-            namespace: spec.local_namespace,
-            name: kname,
-            labels: {
-                [LABELS.managed_by]:  EDO,
-                [LABELS.key_owner]:   spec.owner,
-                [LABELS.key_usage]:   spec.usage,
-            },
-        },
-        spec: {
-            principal:      spec.principal,
-            type:           spec.type,
-            secret:         spec.secret,
-            cluster: {
-                uuid:       spec.cluster,
-                namespace:  spec.namespace,
-    }, }, };
+export async function write (file, docs) {
+    const content = docs.map(d => yaml.stringify(d))
+        .join("...\n");
+    await write_file(file, content);
 }
-

--- a/lib/manifests.js
+++ b/lib/manifests.js
@@ -27,9 +27,8 @@ function read_file (file) {
 }
 
 async function write_file (file, content) {
-    const abs = path.join(this.dir, file);
-    await fs_p.mkdir(path.dirname(abs), { recursive: true });
-    await fs_p.writeFile(abs, content);
+    await fs_p.mkdir(path.dirname(file), { recursive: true });
+    await fs_p.writeFile(file, content);
 }
 
 function unlink_file (file) {

--- a/lib/manifests.js
+++ b/lib/manifests.js
@@ -16,6 +16,15 @@ As such some conventions need to be observed.
 * Cluster-wide object go in \`_cluster/KIND/NAME.yaml\`.
 `;
 
+const FPLUS = "factoryplus.app.amrc.co.uk";
+export const EDO = `edo.${FPLUS}`;
+
+export const LABELS = {
+    managed_by: `app.kubernetes.io/managed-by`,
+    key_owner:  `${EDO}/key-owner`,
+    key_usage:  `${EDO}/key-usage`,
+};
+
 /* The namespace here needs to be kept in sync with the flux system as
  * installed by the shared/flux-system repo. */
 export const FLUX = {
@@ -26,11 +35,14 @@ export const FLUX = {
 };
 
 export const KRB = {
-    group:      "factoryplus.app.amrc.co.uk",
+    group:      FPLUS,
     version:    "v1",
     kind:       "KerberosKey",
     plural:     "kerberos-keys",
 };
+
+/* Manifest to be teleported via flux should not have LABELS.managed_by
+ * as they are not being actively managed on the target cluster. */
 
 export function git_repo (name, url, spec) {
     return {
@@ -74,25 +86,6 @@ export function sealed_secret (namespace, name) {
     }, }, };
 }
 
-export function flux_krb_key (namespace, principal, cluster) {
-    const kname = principal.replace(/@.*/, "").replaceAll("/", ".");
-    return {
-        apiVersion: `${KRB.group}/${KRB.version}`,
-        kind: KRB.kind,
-        metadata: {
-            namespace, 
-            name: kname,
-        },
-        spec: {
-            principal,
-            type:           "Password",
-            secret:         `${FLUX.secret}/password`,
-            cluster: {
-                uuid:       cluster,
-                namespace:  FLUX.ns,
-    }, }, };
-}
-
 export function namespace (name) {
     return {
         apiVersion: "v1",
@@ -100,3 +93,30 @@ export function namespace (name) {
         metadata: { name },
     };
 }
+
+/* Manifests to be installed locally should use LABELS.managed_by. */
+
+export function krb_key (spec) {
+    const kname = `edo.${spec.usage}.${spec.owner}`;
+    return {
+        apiVersion: `${KRB.group}/${KRB.version}`,
+        kind: KRB.kind,
+        metadata: {
+            namespace: spec.local_namespace,
+            name: kname,
+            labels: {
+                [LABELS.managed_by]:  EDO,
+                [LABELS.key_owner]:   spec.owner,
+                [LABELS.key_usage]:   spec.usage,
+            },
+        },
+        spec: {
+            principal:      spec.principal,
+            type:           spec.type,
+            secret:         spec.secret,
+            cluster: {
+                uuid:       spec.cluster,
+                namespace:  spec.namespace,
+    }, }, };
+}
+

--- a/lib/manifests.js
+++ b/lib/manifests.js
@@ -30,6 +30,8 @@ export const LABELS = {
 export const FLUX = {
     ns:         "flux-system",
     secret:     "op1flux-secrets",
+    secretkey:  "password",
+    keytype:    "Password",
     username:   "op1flux/%s",
     branch:     "main",
 };

--- a/lib/manifests.js
+++ b/lib/manifests.js
@@ -74,6 +74,32 @@ export function flux_kust (name, spec) {
     }, }, };
 }
 
+export function flux_helm (spec) {
+    return {
+        apiVersion: "helm.toolkit.fluxcd.io/v2beta1",
+        kind: "HelmRelease",
+        metadata: {
+            namespace: FLUX.ns,
+            name: `${spec.chart}-${spec.uuid}`,
+        },
+        spec: {
+            chart: {
+                spec: {
+                    sourceRef: {
+                        namespace: FLUX.ns,
+                        kind: "GitRepository",
+                        name: spec.repo,
+                    },
+                    chart: "edge-agent",
+                    reconcileStrategy: "Revision",
+                },
+            },
+            interval: "3m0s",
+            values: spec.values,
+        },
+    };
+}
+
 export function sealed_secret (namespace, name) {
     return {
         apiVersion: "bitnami.com/v1alpha1",

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -29,7 +29,7 @@ export class Reconciler {
         const watch = await cdb.watcher();
 
         const app = Edge.App.Deployments;
-        const global = await cdb.get_config(app, app);
+        //const global = await cdb.get_config(app, app);
 
         watch.application(app)
             .pipe(
@@ -50,6 +50,6 @@ export class Reconciler {
     }
 
     async deployment (entries) {
-        
+        this.log("Change: %o", entries);
     }
 }

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -62,18 +62,32 @@ export class Reconciler {
 
     async deployment (entries) {
         this.log("Change: %o", entries);
-        const manifests = entries.flatMap(e =>
-            e.config.charts.map(chart =>
-                flux_helm({
-                    uuid: e.uuid,
-                    chart: chart,
-                    repo: "shared-helm-charts",
-                    values: {
-                        name: `${e.address.group_id}.${e.address.node_id}`,
+
+        const clusters = new Map();
+        for (const entry of entries) {
+            const cl = entry.config.cluster;
+            if (!cl) {
+                this.log("Deployment %s has no cluster", entry.uuid);
+                continue;
+            }
+            if (!clusters.has(cl)) clusters.set(cl, []);
+            clusters.get(cl).push(entry);
+        }
+
+        for (const [cluster, entries] of clusters.entries()) {
+            const manifests = entries.flatMap(e =>
+                e.config.charts.map(chart =>
+                    flux_helm({
                         uuid: e.uuid,
-                        hostname: e.config.hostname,
-                    },
-                })));
-        this.log("Manifests: %o", manifests);
+                        chart: chart,
+                        repo: "shared-helm-charts",
+                        values: {
+                            name: `${e.address.group_id}.${e.address.node_id}`,
+                            uuid: e.uuid,
+                            hostname: e.config.hostname,
+                        },
+                    })));
+            this.log("Manifests for %s: %o", cluster, manifests);
+        }
     }
 }

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -22,6 +22,8 @@ export class Reconciler {
     constructor (opts) {
         this.fplus = opts.fplus;
         this.log = this.fplus.debug.log.bind(this.fplus.debug, "reconcile");
+
+        rx.config.onUnhandledError = e => this.log("Rx error: %o", e);
     }
 
     async init () {
@@ -37,16 +39,16 @@ export class Reconciler {
                 /* Currently the ConfigDB watcher doesn't tell us which
                  * object changed, just that there was a change. This is
                  * a limitation of the underlying MQTT interface and
-                 * can't easily be changed. */
-                rx.map(() => cdb.list_configs(app)),
-                rxx.flatten(), /* await promises */
-                rxx.flatten(), /* flatten list */
-                rx.filter(obj => obj != app),
-                rx.map(cluster => cdb.get_config(app, cluster)
-                    .then(config => ({cluster, config}))),
-                rxx.flatten(), /* await promises */
-                rx.map(({cluster, config}) => Object.entries(config.agents)
-                    .map(([account, {address}]) => ({account, cluster, address}))))
+                 * can't easily be changed. So we need to fetch the
+                 * whole list again every time. */
+                rx.mergeMap(() => cdb.list_configs(app)),
+                rx.mergeMap(list => rx.from(list ?? []).pipe(
+                    rx.filter(obj => obj != app),
+                    rx.mergeMap(agent => cdb.get_config(app, agent)
+                        .then(config => ({agent, config}))),
+                    rx.toArray()),
+                ),
+            )
             .subscribe(this.deployment.bind(this));
     }
 

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -11,7 +11,7 @@ import { Debug, UUIDs } from "@amrc-factoryplus/utilities";
 
 import { Checkout }         from "./checkout.js";
 import { Clusters }         from "./clusters.js";
-import { flux_helm }        from "./manifests.js";
+import { flux_helm }        from "./templates.js";
 import { SealedSecrets }    from "./secrets.js";
 import { Edge }             from "./uuids.js";
 

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -11,6 +11,7 @@ import { Debug, UUIDs } from "@amrc-factoryplus/utilities";
 
 import { Checkout }         from "./checkout.js";
 import { Clusters }         from "./clusters.js";
+import { flux_helm }        from "./manifests.js";
 import { SealedSecrets }    from "./secrets.js";
 import { Edge }             from "./uuids.js";
 
@@ -32,6 +33,9 @@ export class Reconciler {
 
         const app = Edge.App.Deployments;
         //const global = await cdb.get_config(app, app);
+        
+        const cdb_lookup = (uuid$, app) =>
+            uuid$.pipe(rx.mergeMap(uuid => cdb.get_config(app, uuid)));
 
         watch.application(app)
             .pipe(
@@ -44,8 +48,12 @@ export class Reconciler {
                 rx.mergeMap(() => cdb.list_configs(app)),
                 rx.mergeMap(list => rx.from(list ?? []).pipe(
                     rx.filter(obj => obj != app),
-                    rx.mergeMap(agent => cdb.get_config(app, agent)
-                        .then(config => ({agent, config}))),
+                    rx.connect(agent$ => rx.zip(
+                        agent$,
+                        cdb_lookup(agent$, app),
+                        cdb_lookup(agent$, UUIDs.App.SparkplugAddress),
+                        (u, c, a) => ({uuid: u, config: c, address: a})
+                    )),
                     rx.toArray()),
                 ),
             )
@@ -54,5 +62,18 @@ export class Reconciler {
 
     async deployment (entries) {
         this.log("Change: %o", entries);
+        const manifests = entries.flatMap(e =>
+            e.config.charts.map(chart =>
+                flux_helm({
+                    uuid: e.uuid,
+                    chart: chart,
+                    repo: "shared-helm-charts",
+                    values: {
+                        name: `${e.address.group_id}.${e.address.node_id}`,
+                        uuid: e.uuid,
+                        hostname: e.config.hostname,
+                    },
+                })));
+        this.log("Manifests: %o", manifests);
     }
 }

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -39,11 +39,12 @@ export class Reconciler {
                  * a limitation of the underlying MQTT interface and
                  * can't easily be changed. */
                 rx.map(() => cdb.list_configs(app)),
-                rxx.flatten(), rxx.flatten(),
+                rxx.flatten(), /* await promises */
+                rxx.flatten(), /* flatten list */
                 rx.filter(obj => obj != app),
                 rx.map(cluster => cdb.get_config(app, cluster)
                     .then(config => ({cluster, config}))),
-                rxx.flatten(),
+                rxx.flatten(), /* await promises */
                 rx.map(({cluster, config}) => Object.entries(config.agents)
                     .map(([account, {address}]) => ({account, cluster, address}))))
             .subscribe(this.deployment.bind(this));

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -1,0 +1,55 @@
+/*
+ * Factory+ / AMRC Connectivity Stack (ACS) Edge Deployment operator
+ * Reconciliation operator
+ * Copyright 2023 AMRC
+ */
+
+import rx from "rxjs";
+import { merge } from "json-merge-patch";
+
+import { Debug, UUIDs } from "@amrc-factoryplus/utilities";
+
+import { Checkout }         from "./checkout.js";
+import { Clusters }         from "./clusters.js";
+import { SealedSecrets }    from "./secrets.js";
+import { Edge }             from "./uuids.js";
+
+import { rxx } from "./rxx.js";
+
+const debug = new Debug();
+
+export class Reconciler {
+    constructor (opts) {
+        this.fplus = opts.fplus;
+        this.log = this.fplus.debug.log.bind(this.fplus.debug, "reconcile");
+    }
+
+    async init () {
+        const cdb = this.fplus.ConfigDB;
+        const watch = await cdb.watcher();
+
+        const app = Edge.App.Deployments;
+        const global = await cdb.get_config(app, app);
+
+        watch.application(app)
+            .pipe(
+                rx.startWith(undefined),
+                /* Currently the ConfigDB watcher doesn't tell us which
+                 * object changed, just that there was a change. This is
+                 * a limitation of the underlying MQTT interface and
+                 * can't easily be changed. */
+                rx.map(() => cdb.list_configs(app)),
+                rxx.flatten(), rxx.flatten(),
+                rx.filter(obj => obj != app),
+                rx.map(cluster => cdb.get_config(app, cluster)
+                    .then(config => ({cluster, config}))),
+                rxx.flatten(),
+                rx.map(({cluster, config}) => Object.entries(config.agents)
+                    .map(([account, {address}]) => ({account, cluster, address}))))
+            .subscribe(this.deployment.bind(this));
+    }
+
+    async deployment (entries) {
+        
+    }
+}

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -22,45 +22,49 @@ const debug = new Debug();
 export class Reconciler {
     constructor (opts) {
         this.fplus = opts.fplus;
+        this.cdb = this.fplus.ConfigDB;
         this.log = this.fplus.debug.log.bind(this.fplus.debug, "reconcile");
 
         rx.config.onUnhandledError = e => this.log("Rx error: %o", e);
     }
 
     async init () {
-        const cdb = this.fplus.ConfigDB;
-        const watch = await cdb.watcher();
+        const watch = await this.cdb.watcher();
 
         const app = Edge.App.Deployments;
         //const global = await cdb.get_config(app, app);
         
-        const cdb_lookup = (uuid$, app) =>
-            uuid$.pipe(rx.mergeMap(uuid => cdb.get_config(app, uuid)));
-
         watch.application(app)
             .pipe(
                 rx.startWith(undefined),
-                /* Currently the ConfigDB watcher doesn't tell us which
-                 * object changed, just that there was a change. This is
-                 * a limitation of the underlying MQTT interface and
-                 * can't easily be changed. So we need to fetch the
-                 * whole list again every time. */
-                rx.mergeMap(() => cdb.list_configs(app)),
-                rx.mergeMap(list => rx.from(list ?? []).pipe(
-                    rx.filter(obj => obj != app),
-                    rx.connect(agent$ => rx.zip(
-                        agent$,
-                        cdb_lookup(agent$, app),
-                        cdb_lookup(agent$, UUIDs.App.SparkplugAddress),
-                        (u, c, a) => ({uuid: u, config: c, address: a})
-                    )),
-                    rx.toArray()),
-                ),
+                rx.mergeMap(() => this.cdb.list_configs(app)),
+                rx.mergeMap(list => this.lookup_deployments(list)),
             )
-            .subscribe(this.deployment.bind(this));
+            .subscribe(this.handle_deployments.bind(this));
     }
 
-    async deployment (entries) {
+    cdb_lookup (uuid$, app) {
+        return uuid$.pipe(
+            rx.mergeMap(uuid => this.cdb.get_config(app, uuid)));
+    }
+
+    lookup_deployments (list) {
+        const app = Edge.App.Deployments;
+
+        if (!list) return rx.of([]);
+
+        return rx.from(list).pipe(
+            rx.filter(obj => obj != app),
+            rx.connect(agent$ => rx.zip(
+                agent$,
+                this.cdb_lookup(agent$, app),
+                this.cdb_lookup(agent$, UUIDs.App.SparkplugAddress),
+                (u, c, a) => ({uuid: u, config: c, address: a})
+            )),
+            rx.toArray());
+    }
+
+    async handle_deployments (entries) {
         this.log("Change: %o", entries);
 
         const clusters = new Map();
@@ -75,23 +79,34 @@ export class Reconciler {
         }
 
         for (const [cluster, entries] of clusters.entries()) {
-            const manifests = entries.flatMap(e =>
-                e.config.charts.map(chart => {
-                    const name = e.address
-                        ? `${e.address.group_id}.${e.address.node_id}`
-                        : e.uuid;
-                    return flux_helm({
-                        uuid: e.uuid,
-                        chart: chart,
-                        repo: "shared-helm-charts",
-                        values: {
-                            name,
-                            uuid: e.uuid,
-                            hostname: e.config.hostname,
-                        },
-                    });
-                }));
-            this.log("Manifests for %s: %o", cluster, manifests);
+            /* XXX This would be better in Rx, but I'm not sure it's
+             * staying. Do these serially for now. */
+            const repo = await this.cdb.get_config(Edge.App.Cluster, cluster);
+            if (!repo) {
+                this.log("No repo configuration for %s", cluster);
+                continue;
+            }
+            await this.handle_cluster(repo.flux, entries);
         }
+    }
+
+    async handle_cluster (url, deployments) {
+        const manifests = deployments.flatMap(dep =>
+            dep.config.charts.map(chart => {
+                const name = dep.address
+                    ? `${dep.address.group_id}.${dep.address.node_id}`
+                    : dep.uuid;
+                return flux_helm({
+                    uuid: dep.uuid,
+                    chart: chart,
+                    repo: "shared-helm-charts",
+                    values: {
+                        name,
+                        uuid: dep.uuid,
+                        hostname: dep.config.hostname,
+                    },
+                });
+            }));
+        this.log("Manifests for %s: %o", url, manifests);
     }
 }

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -82,15 +82,16 @@ export class Reconciler {
             clusters.get(cl).push(entry);
         }
 
+        /* Update changed deployments */
         for (const [cluster, entries] of clusters.entries()) {
-            /* XXX This would be better in Rx, but I'm not sure it's
-             * staying. Do these serially for now. */
-            const repo = await this.cdb.get_config(Edge.App.Cluster, cluster);
-            if (!repo) {
-                this.log("No repo configuration for %s", cluster);
-                continue;
-            }
-            await this.handle_cluster(cluster, repo.flux, entries);
+            await this.handle_cluster(cluster, entries);
+        }
+
+        /* Clear clusters with no deployments */
+        const all_clusters = await this.cdb.list_configs(Edge.App.Cluster);
+        for (const cl of all_clusters) {
+            if (clusters.has(cl)) continue;
+            await this.handle_cluster(cl, []);
         }
     }
 
@@ -113,7 +114,16 @@ export class Reconciler {
             }));
     }
 
-    async handle_cluster (uuid, url, deployments) {
+    async handle_cluster (uuid, deployments) {
+        /* XXX This would be better in Rx, but I'm not sure it's
+         * staying. Do these calls serially for now. */
+        const repo = await this.cdb.get_config(Edge.App.Cluster, uuid);
+        if (!repo) {
+            this.log("No repo configuration for %s", uuid);
+            return;
+        }
+        const url = repo.flux;
+
         const manifests = this.manifests_for_deployments(deployments);
         this.log("Manifests for %s: %o", url, manifests);
 

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -47,11 +47,6 @@ export class Reconciler {
             .subscribe(this.handle_deployments.bind(this));
     }
 
-    cdb_lookup (uuid$, app) {
-        return uuid$.pipe(
-            rx.mergeMap(uuid => this.cdb.get_config(app, uuid)));
-    }
-
     lookup_deployments (list) {
         const app = Edge.App.Deployments;
 
@@ -59,18 +54,16 @@ export class Reconciler {
 
         return rx.from(list).pipe(
             rx.filter(obj => obj != app),
-            rx.connect(agent$ => rx.zip(
-                agent$,
-                this.cdb_lookup(agent$, app),
-                this.cdb_lookup(agent$, UUIDs.App.SparkplugAddress),
-                (u, c, a) => ({uuid: u, config: c, address: a})
-            )),
+            rx.mergeMap(agent => Promise.all([
+                agent,
+                this.cdb.get_config(app, agent),
+                this.cdb.get_config(UUIDs.App.SparkplugAddress, agent),
+            ])),
+            rx.map(([u, c, a]) => ({uuid: u, config: c, address: a})),
             rx.toArray());
     }
 
     async handle_deployments (entries) {
-        this.log("Change: %o", entries);
-
         const clusters = new Map();
         for (const entry of entries) {
             const cl = entry.config.cluster;
@@ -124,8 +117,9 @@ export class Reconciler {
         }
         const url = repo.flux;
 
+        this.log("Deploying to %s: %s", repo.name, 
+            deployments.map(d => d.uuid).join(", "));
         const manifests = this.manifests_for_deployments(deployments);
-        this.log("Manifests for %s: %o", url, manifests);
 
         const co = await Checkout.clone({ fplus: this.fplus, url });
         const dir = co.path_for(uuid, "deployment");

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -76,17 +76,21 @@ export class Reconciler {
 
         for (const [cluster, entries] of clusters.entries()) {
             const manifests = entries.flatMap(e =>
-                e.config.charts.map(chart =>
-                    flux_helm({
+                e.config.charts.map(chart => {
+                    const name = e.address
+                        ? `${e.address.group_id}.${e.address.node_id}`
+                        : e.uuid;
+                    return flux_helm({
                         uuid: e.uuid,
                         chart: chart,
                         repo: "shared-helm-charts",
                         values: {
-                            name: `${e.address.group_id}.${e.address.node_id}`,
+                            name,
                             uuid: e.uuid,
                             hostname: e.config.hostname,
                         },
-                    })));
+                    });
+                }));
             this.log("Manifests for %s: %o", cluster, manifests);
         }
     }

--- a/lib/reconciler.js
+++ b/lib/reconciler.js
@@ -4,6 +4,9 @@
  * Copyright 2023 AMRC
  */
 
+import fs_p from "fs/promises";
+import path from "path";
+
 import rx from "rxjs";
 import { merge } from "json-merge-patch";
 
@@ -11,6 +14,7 @@ import { Debug, UUIDs } from "@amrc-factoryplus/utilities";
 
 import { Checkout }         from "./checkout.js";
 import { Clusters }         from "./clusters.js";
+import * as Manifests       from "./manifests.js";
 import { flux_helm }        from "./templates.js";
 import { SealedSecrets }    from "./secrets.js";
 import { Edge }             from "./uuids.js";
@@ -86,12 +90,12 @@ export class Reconciler {
                 this.log("No repo configuration for %s", cluster);
                 continue;
             }
-            await this.handle_cluster(repo.flux, entries);
+            await this.handle_cluster(cluster, repo.flux, entries);
         }
     }
 
-    async handle_cluster (url, deployments) {
-        const manifests = deployments.flatMap(dep =>
+    manifests_for_deployments (deployments) {
+        return deployments.flatMap(dep =>
             dep.config.charts.map(chart => {
                 const name = dep.address
                     ? `${dep.address.group_id}.${dep.address.node_id}`
@@ -107,6 +111,20 @@ export class Reconciler {
                     },
                 });
             }));
+    }
+
+    async handle_cluster (uuid, url, deployments) {
+        const manifests = this.manifests_for_deployments(deployments);
         this.log("Manifests for %s: %o", url, manifests);
+
+        const co = await Checkout.clone({ fplus: this.fplus, url });
+        const dir = co.path_for(uuid, "deployment");
+        await fs_p.rm(dir, { force: true, recursive: true });
+        for (const mani of manifests) {
+            const name = mani.metadata.name;
+            const file = path.join(dir, `${name}.yaml`);
+            await Manifests.write(file, [mani]);
+        }
+        await co.push("Update deployments");
     }
 }

--- a/lib/rxx.js
+++ b/lib/rxx.js
@@ -7,5 +7,6 @@
 import rx from "rxjs";
 
 export const rxx = {
-    flatten: () => rx.mergeMap(v => rx.from(v)),
+    flatten: () => rx.mergeMap(v => 
+        v != null ? rx.from(v) : rx.EMPTY),
 };

--- a/lib/rxx.js
+++ b/lib/rxx.js
@@ -1,0 +1,11 @@
+/*
+ * Factory+ / AMRC Connectivity Stack (ACS) Edge Deployment operator
+ * Rx extensions.
+ * Copyright 2023 AMRC
+ */
+
+import rx from "rxjs";
+
+export const rxx = {
+    flatten: () => rx.mergeMap(v => rx.from(v)),
+};

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,0 +1,152 @@
+/*
+ * Factory+ / AMRC Connectivity Stack (ACS) Edge Deployment operator
+ * Manifest creation functions
+ * Copyright 2023 AMRC
+ */
+
+export const README = `
+This repo is managed by the Edge Deployment Operator.
+As such some conventions need to be observed.
+
+* All manifests must be 1-per-file.
+* All manifests must be YAML, but any comments or formatting are likely
+    to be removed by the operator.
+* Namespaced objects go in \`NAMESPACE/KIND/NAME.yaml\`,
+    e.g. \`fplus-edge/Deployment/edge-agent.yaml\`.
+* Cluster-wide object go in \`_cluster/KIND/NAME.yaml\`.
+`;
+
+const FPLUS = "factoryplus.app.amrc.co.uk";
+export const EDO = `edo.${FPLUS}`;
+
+export const LABELS = {
+    managed_by: `app.kubernetes.io/managed-by`,
+    key_owner:  `${EDO}/key-owner`,
+    key_usage:  `${EDO}/key-usage`,
+};
+
+/* The namespace here needs to be kept in sync with the flux system as
+ * installed by the shared/flux-system repo. */
+export const FLUX = {
+    ns:         "flux-system",
+    secret:     "op1flux-secrets",
+    secretkey:  "password",
+    keytype:    "Password",
+    username:   "op1flux/%s",
+    branch:     "main",
+};
+
+export const KRB = {
+    group:      FPLUS,
+    version:    "v1",
+    kind:       "KerberosKey",
+    plural:     "kerberos-keys",
+};
+
+/* Manifest to be teleported via flux should not have LABELS.managed_by
+ * as they are not being actively managed on the target cluster. */
+
+export function git_repo (name, url, spec) {
+    return {
+        apiVersion: "source.toolkit.fluxcd.io/v1",
+        kind: "GitRepository",
+        metadata: { namespace: FLUX.ns, name },
+        spec: {
+          interval: spec.interval,
+          ref: { branch: spec.branch },
+          secretRef: { name: FLUX.secret },
+          url,
+    }, };
+}
+
+export function flux_kust (name, spec) {
+    return {
+        apiVersion: "kustomize.toolkit.fluxcd.io/v1",
+        kind: "Kustomization",
+        metadata: { namespace: FLUX.ns, name },
+        spec: {
+            interval: spec.interval,
+            path: "./",
+            prune: true,
+            sourceRef: {
+                kind: "GitRepository",
+                name: name,
+    }, }, };
+}
+
+export function flux_helm (spec) {
+    return {
+        apiVersion: "helm.toolkit.fluxcd.io/v2beta1",
+        kind: "HelmRelease",
+        metadata: {
+            namespace: FLUX.ns,
+            name: `${spec.chart}-${spec.uuid}`,
+        },
+        spec: {
+            chart: {
+                spec: {
+                    sourceRef: {
+                        namespace: FLUX.ns,
+                        kind: "GitRepository",
+                        name: spec.repo,
+                    },
+                    chart: "edge-agent",
+                    reconcileStrategy: "Revision",
+                },
+            },
+            interval: "3m0s",
+            install: { disableWait: true },
+            upgrade: { disableWait: true },
+            values: spec.values,
+        },
+    };
+}
+
+export function sealed_secret (namespace, name) {
+    return {
+        apiVersion: "bitnami.com/v1alpha1",
+        kind: "SealedSecret",
+        metadata: { namespace, name },
+        spec: {
+            encryptedData: {},
+            template: {
+                data: null,
+                metadata: { namespace, name },
+                type: "Opaque",
+    }, }, };
+}
+
+export function namespace (name) {
+    return {
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: { name },
+    };
+}
+
+/* Manifests to be installed locally should use LABELS.managed_by. */
+
+export function krb_key (spec) {
+    const kname = `edo.${spec.usage}.${spec.owner}`;
+    return {
+        apiVersion: `${KRB.group}/${KRB.version}`,
+        kind: KRB.kind,
+        metadata: {
+            namespace: spec.local_namespace,
+            name: kname,
+            labels: {
+                [LABELS.managed_by]:  EDO,
+                [LABELS.key_owner]:   spec.owner,
+                [LABELS.key_usage]:   spec.usage,
+            },
+        },
+        spec: {
+            principal:      spec.principal,
+            type:           spec.type,
+            secret:         spec.secret,
+            cluster: {
+                uuid:       spec.cluster,
+                namespace:  spec.namespace,
+    }, }, };
+}
+

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -5,10 +5,9 @@
 
 export const Edge = {
     App: {
-        Cluster:    "bdb13634-0b3d-4e38-a065-9d88c12ee78d",
-        Template:   "72804a19-636b-4836-b62b-7ad1476f2b86",
-        Host:       "c6120703-48ff-46d1-a4fc-037078ea8bfb",
-        Agent:      "c6120703-48ff-46d1-a4fc-037078ea8bfb",
+        Cluster:        "bdb13634-0b3d-4e38-a065-9d88c12ee78d",
+        Template:       "72804a19-636b-4836-b62b-7ad1476f2b86",
+        Deployments:    "f2b9417a-ef7f-421f-b387-bb8183a48cdb",
     },
     Class: {
         Cluster:    "f24d354d-abc1-4e32-98e1-0667b3e40b61",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-edge-deployment",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@amrc-factoryplus/sparkplug-app": "^0.0.1",
-    "@amrc-factoryplus/utilities": "^1.0.8",
+    "@amrc-factoryplus/utilities": "1.0.10-bmz1",
     "@kubernetes/client-node": "^0.18.1",
     "concat-stream": "^2.0.0",
     "isomorphic-git": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@amrc-factoryplus/sparkplug-app": "^0.0.1",
     "@amrc-factoryplus/utilities": "^1.0.8",
     "@kubernetes/client-node": "^0.18.1",
     "concat-stream": "^2.0.0",
     "isomorphic-git": "^1.24.0",
+    "json-merge-patch": "^1.0.2",
+    "rxjs": "^7.8.1",
     "tmp-promise": "^3.0.3",
     "yaml": "^2.3.1"
   }


### PR DESCRIPTION
Read ConfigDB entries specifying Edge Agent deployments and push them to the cluster git repos.

This mechanism is very generic: the references are to Helm charts distributed via another on-cluster git repo, so we can deploy anything like this. Additional translator modules can be handled as additional Helm charts.