### PR TITLE
Create a cluster bootstrap script

### DIFF
--- a/dumps/edge-deploy-auth.yaml
+++ b/dumps/edge-deploy-auth.yaml
@@ -60,6 +60,9 @@ aces:
   - principal: !u E.Requirement.ServiceAccount
     permission: !u FP.Permission.ConfigDB.ReadConfig
     target: !u E.App.HelmRelease
+  - principal: !u E.Requirement.ServiceAccount
+    permission: !u FP.Permission.ConfigDB.ReadConfig
+    target: !u E.App.Bootstrap
 
   - principal: !u E.Requirement.ServiceAccount
     permission: !u FP.Permission.ConfigDB.WriteConfig

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -130,6 +130,7 @@ export class Update extends Action {
             await co.write_manifests(dir, file, docs);
         }
         await co.push("Cluster flux update");
+        this.update({ self_link: flux["self-link.yaml"] });
     }
 
     async flux () {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -5,6 +5,7 @@
  */
 
 import rx from "rxjs";
+import yaml from "yaml";
 
 import { UUIDs }        from "@amrc-factoryplus/utilities";
 
@@ -130,7 +131,10 @@ export class Update extends Action {
             await co.write_manifests(dir, file, docs);
         }
         await co.push("Cluster flux update");
-        this.update({ self_link: flux["self-link.yaml"] });
+        const self_link = flux["self-link.yaml"]
+            .map(obj => yaml.stringify(obj, null, { directives: true }))
+            .join("...\n");
+        this.update({ self_link });
     }
 
     async flux () {

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,13 +20,14 @@ export class App {
             git_email:          env.GIT_EMAIL,
         });
 
-        this.clusters = new Clusters({
+        const clusters = this.clusters = new Clusters({
             fplus,
+            krbkeys:            env.KRBKEYS_IMAGE,
             realm:              env.REALM,
         });
 
         this.edge = new EdgeDeploy({
-            fplus,
+            fplus, clusters,
             realm:      env.REALM,
             http_url:   env.HTTP_API_URL,
             cert_dir:   env.KUBESEAL_TEMP,
@@ -50,6 +51,7 @@ export class App {
             routes: app => {
                 app.use("/v1", this.edge.routes);
             },
+            public: /^\/v1\/cluster\/[-0-9a-f]{36}\/bootstrap$/,
         });
     }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -28,9 +28,7 @@ export class App {
 
         this.edge = new EdgeDeploy({
             fplus, clusters,
-            realm:      env.REALM,
             http_url:   env.HTTP_API_URL,
-            cert_dir:   env.KUBESEAL_TEMP,
         });
 
         this.api = new WebAPI({
@@ -51,7 +49,7 @@ export class App {
             routes: app => {
                 app.use("/v1", this.edge.routes);
             },
-            public: /^\/v1\/cluster\/[-0-9a-f]{36}\/bootstrap$/,
+            public: "/v1/cluster/:uuid/bootstrap",
         });
     }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -28,7 +28,8 @@ export class App {
 
         this.edge = new EdgeDeploy({
             fplus, clusters,
-            http_url:   env.HTTP_API_URL,
+            http_url:       env.HTTP_API_URL,
+            external_url:   env.EXTERNAL_URL,
         });
 
         this.api = new WebAPI({

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -201,7 +201,7 @@ export class Checkout {
     async write_manifests (dir, file, docs) {
         const fpath = path.join(dir, file);
         const content = docs.map(d => yaml.stringify(d, { directives: true }))
-            .join("\n");
+            .join("...\n");
         await this.write_file(fpath, content);
     }
 

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -200,8 +200,8 @@ export class Checkout {
 
     async write_manifests (dir, file, docs) {
         const fpath = path.join(dir, file);
-        const content = docs.map(d => yaml.stringify(d))
-            .join("...\n");
+        const content = docs.map(d => yaml.stringify(d, { directives: true }))
+            .join("\n");
         await this.write_file(fpath, content);
     }
 

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -106,6 +106,13 @@ export class Checkout {
         return new Checkout(opts).init();
     }
 
+    static async fetch_file (opts) {
+        const co = await Checkout.clone(opts);
+        const file = await co.read_file(opts.path);
+        await co.dispose();
+        return file;
+    }
+
     async commit (message, ...args) {
         if (args.length)
             message = util.format(message, ...args);

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -4,6 +4,7 @@
  * Copyright 2023 AMRC
  */
 
+import crypto from "crypto";
 import stream from "stream";
 
 import Imm      from "immutable";
@@ -192,13 +193,9 @@ export class Clusters {
         this.log("Generated bootstrap for %s", uuid);
 
         bootstrap.files["flux-system.yaml"] = this.flux_system;
-        bootstrap.files["self-link.yaml"] = await Checkout.fetch_file({
-            fplus:  this.fplus,
-            uuid,
-            path:   "edo/cluster/self-link.yaml",
-        });
+        bootstrap.files["self-link.yaml"] = status.self_link;
         
-        const marker = "END_OF_FILE";
+        const marker = crypto.randomBytes(15).toString("base64url");
         const files = Object.entries(bootstrap.files)
             .map(([n, f]) => `cat >${n} <<'${marker}'\n${f}\n${marker}`)
             .join("\n");

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -20,14 +20,16 @@ import { Edge }                 from "./uuids.js";
 export class Clusters {
     constructor (opts) {
         this.fplus      = opts.fplus;
+        this.krbkeys    = opts.krbkeys;
         /* This is used by actions.js */
         this.realm      = opts.realm;
 
         this.log        = this.fplus.debug.bound("edge");
+        this.cdb        = this.fplus.ConfigDB;
     }
 
     async init () {
-        const cdb = this.fplus.ConfigDB;
+        const { cdb } = this;
         const watcher = await cdb.watcher();
 
         /* XXX We could track changes here, but this is only updated by
@@ -36,13 +38,15 @@ export class Clusters {
             UUIDs.App.ServiceConfig, Edge.Service.EdgeDeployment);
 
         /* XXX We should track changes here, and update the cluster. */
-        const tmpl = (app, obj) => cdb.get_config(app, obj)
+        const tmpl = (app, obj) => cdb.get_config(app, obj ?? app)
             .then(t => Template(t));
         this.template = {
-            flux:       await tmpl(Edge.App.Flux, Edge.App.Flux),
+            flux:       await tmpl(Edge.App.Flux),
             cluster:    await tmpl(Edge.App.HelmChart, this.config.helm.cluster),
-            helm:       await tmpl(Edge.App.HelmRelease, Edge.App.HelmRelease),
+            helm:       await tmpl(Edge.App.HelmRelease),
+            bootstrap:  await tmpl(Edge.App.Bootstrap),
         };
+        this.flux_system = await this._init_flux_system();
 
         /* [uuid, patch] requesting status updates */
         this.status_updates = new rx.Subject();
@@ -54,6 +58,14 @@ export class Clusters {
         this.cluster_updates = this._init_cluster_updates(clusters);
 
         return this;
+    }
+
+    _init_flux_system () {
+        return Checkout.fetch_file({
+            fplus:  this.fplus,
+            uuid:   this.config.repo.helm.uuid,
+            path:   "flux-system/flux-system.yaml",
+        });
     }
 
     /* Obs of Set(uuid) indicating the clusters in the ConfigDB */
@@ -156,4 +168,41 @@ export class Clusters {
         this.status_patches.subscribe();
         this.cluster_updates.subscribe();
     }
+
+    async cluster_status (uuid) {
+        const st = await rx.firstValueFrom(this.status);
+        return st.get(uuid, {});
+    }
+
+    async bootstrap (uuid) {
+        const status = await this.cluster_status(uuid);
+        if (!status.ready) return null;
+
+        const { namespace, name } = status.spec;
+        const cluster = this.template.cluster({ name, uuid });
+        /* We pull values from the edge-cluster Helm chart values. This
+         * means we need to stay in sync with that Helm chart. */
+        const bootstrap = this.template.bootstrap({
+            name, namespace,
+            realm:      cluster.values.krb5.realm,
+            domain:     cluster.values.cluster.domain,
+            krbkeys:    this.krbkeys,
+            files:      "@@@@@",
+        });
+        this.log("Generated bootstrap for %s", uuid);
+
+        bootstrap.files["flux-system.yaml"] = this.flux_system;
+        bootstrap.files["self-link.yaml"] = await Checkout.fetch_file({
+            fplus:  this.fplus,
+            uuid,
+            path:   "edo/cluster/self-link.yaml",
+        });
+        
+        const marker = "END_OF_FILE";
+        const files = Object.entries(bootstrap.files)
+            .map(([n, f]) => `cat >${n} <<'${marker}'\n${f}\n${marker}`)
+            .join("\n");
+        return bootstrap.wrapper.replace("@@@@@", files);
+    }
+
 }

--- a/lib/edge-deploy.js
+++ b/lib/edge-deploy.js
@@ -41,6 +41,8 @@ export class EdgeDeploy {
 
         const app = this.routes;
         app.get("/cluster/:cluster/bootstrap", this.wrap(this.bootstrap));
+        app.post("/cluster/:cluster/bootstrap-url", 
+            this.wrap(this.bootstrap_url));
         app.get("/cluster/:cluster/status", this.wrap(this.cluster_status));
         app.route("/cluster/:cluster/secret/:namespace/:name/:key")
             .put(this.wrap(this.seal_secret))
@@ -56,6 +58,20 @@ export class EdgeDeploy {
 
         if (!bs) return res.status(404).end();
         return res.status(200).type("text/plain").send(bs);
+    }
+
+    async bootstrap_url (req, res) {
+        const { cluster } = req.params;
+
+        const ok = await this.fplus.Auth.check_acl(
+            req.auth, Edge.Perm.Clusters, cluster, true);
+        if (!ok) return res.status(403).end();
+
+        const rv = await this.clusters.cluster_status(cluster);
+        if (!rv?.ready)
+            return res.status(404).end();
+
+        return res.status(200).json(`./bootstrap`);
     }
 
     async cluster_status (req, res) {

--- a/lib/edge-deploy.js
+++ b/lib/edge-deploy.js
@@ -14,9 +14,10 @@ import { Edge }             from "./uuids.js";
 
 export class EdgeDeploy {
     constructor (opts) {
-        this.fplus      = opts.fplus;
-        this.http_url   = opts.http_url;
-        this.clusters   = opts.clusters;
+        this.fplus          = opts.fplus;
+        this.http_url       = opts.http_url;
+        this.external_url   = opts.external_url;
+        this.clusters       = opts.clusters;
 
         this.log = this.fplus.debug.bound("edge");
         this.routes = express.Router();
@@ -71,7 +72,9 @@ export class EdgeDeploy {
         if (!rv?.ready)
             return res.status(404).end();
 
-        return res.status(200).json(`./bootstrap`);
+        const url = new URL(`/v1/cluster/${cluster}/bootstrap`,
+            this.external_url).toString();
+        return res.status(200).json(url);
     }
 
     async cluster_status (req, res) {

--- a/lib/edge-deploy.js
+++ b/lib/edge-deploy.js
@@ -16,6 +16,7 @@ export class EdgeDeploy {
     constructor (opts) {
         this.fplus      = opts.fplus;
         this.http_url   = opts.http_url;
+        this.clusters   = opts.clusters;
 
         this.log = this.fplus.debug.bound("edge");
         this.routes = express.Router();
@@ -39,12 +40,22 @@ export class EdgeDeploy {
             Edge.Service.EdgeDeployment, this.http_url);
 
         const app = this.routes;
-        //app.get("/cluster/:cluster/status", this.wrap(this.cluster_status));
+        app.get("/cluster/:cluster/bootstrap", this.wrap(this.bootstrap));
+        app.get("/cluster/:cluster/status", this.wrap(this.cluster_status));
         app.route("/cluster/:cluster/secret/:namespace/:name/:key")
             .put(this.wrap(this.seal_secret))
             .delete(this.wrap(this.delete_sealed_secret));
 
         return this;
+    }
+
+    async bootstrap (req, res) {
+        const { cluster } = req.params;
+
+        const bs = await this.clusters.bootstrap(cluster);
+
+        if (!bs) return res.status(404).end();
+        return res.status(200).type("text/plain").send(bs);
     }
 
     async cluster_status (req, res) {

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -10,6 +10,7 @@ export const Edge = {
         Flux:           "72804a19-636b-4836-b62b-7ad1476f2b86",
         HelmChart:      "729fe070-5e67-4bc7-94b5-afd75cb42b03",
         HelmRelease:    "88436128-09a3-4c9c-b7f4-b0e495137265",
+        Bootstrap:      "a807d8fc-63ff-48bb-85c7-82b93beb606e",
     },
     Class: {
         Cluster:    "f24d354d-abc1-4e32-98e1-0667b3e40b61",


### PR DESCRIPTION
Create a URL which exposes a bootstrap script for an edge cluster. We need to feed YAML manifests to `kubectl`, so this needs to be a self-unpacking script. We also have to include all the Flux manifests so the script ends up quite large.

We could make the script smaller by gzipping and base64ing the included files, but I'm not inclined to do that as it makes it harder for an administrator to audit the script before running it.

Currently the script-generation URL is fully public (unauthenticated). I would prefer for it to include an expiring token of some sort, so provide a second URL for the Manager to use to retrieve a URL for a bootstrap script. Then we can change the bootstrap URL in future.

Draft until #9 is merged.