### PR TITLE
Make use of service-setup

### DIFF
--- a/dumps/edge-deploy-auth.json
+++ b/dumps/edge-deploy-auth.json
@@ -64,6 +64,11 @@
     },
     {
       "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+      "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
+      "target": "a807d8fc-63ff-48bb-85c7-82b93beb606e"
+    },
+    {
+      "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
       "permission": "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
       "target": "64a8bfa9-7772-45c4-9d1a-9e6290690957"
     },

--- a/dumps/edge-deploy-configdb.json
+++ b/dumps/edge-deploy-configdb.json
@@ -96,6 +96,11 @@
           "namespace": {
             "description": "The k8s namespace to deploy to.",
             "type": "string"
+          },
+          "chart": {
+            "description": "The Helm chart to deploy.",
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/dumps/edge-deploy-configdb.json
+++ b/dumps/edge-deploy-configdb.json
@@ -3,7 +3,6 @@
   "version": 1,
   "classes": [
     "f24d354d-abc1-4e32-98e1-0667b3e40b61",
-    "f9be0334-0ff7-43d3-9d8a-188d3e4d472b",
     "265d481f-87a7-4f93-8fc6-53fa64dc11bb",
     "ac0d5288-6136-4ced-a372-325fbbcdd70d",
     "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad",
@@ -13,7 +12,6 @@
     "d319bd87-f42b-4b66-be4f-f82ff48b93f0": [
       "bdb13634-0b3d-4e38-a065-9d88c12ee78d",
       "f6c67e6f-e48e-4f69-b4bb-bfbddcc2a517",
-      "72804a19-636b-4836-b62b-7ad1476f2b86",
       "729fe070-5e67-4bc7-94b5-afd75cb42b03",
       "88436128-09a3-4c9c-b7f4-b0e495137265",
       "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3"
@@ -41,17 +39,11 @@
       "f24d354d-abc1-4e32-98e1-0667b3e40b61": {
         "name": "Edge cluster"
       },
-      "f9be0334-0ff7-43d3-9d8a-188d3e4d472b": {
-        "name": "Edge cluster template"
-      },
       "bdb13634-0b3d-4e38-a065-9d88c12ee78d": {
         "name": "Edge cluster configuration"
       },
       "f6c67e6f-e48e-4f69-b4bb-bfbddcc2a517": {
         "name": "Edge cluster setup status"
-      },
-      "72804a19-636b-4836-b62b-7ad1476f2b86": {
-        "name": "Edge cluster Flux template"
       },
       "729fe070-5e67-4bc7-94b5-afd75cb42b03": {
         "name": "Helm chart template"
@@ -111,96 +103,6 @@
         "title": "EDO private status",
         "type": "object",
         "additionalProperties": true
-      },
-      "72804a19-636b-4836-b62b-7ad1476f2b86": {
-        "title": "Edge cluster Flux template",
-        "description": "A template for creating an edge cluster Flux repo. Values that are strings will have {{handlebar}} templates expanded.\n",
-        "type": "object",
-        "required": [
-          "self-link.yaml"
-        ],
-        "additionalProperties": {
-          "description": "A file to include in the flux repo. The key gives the name of the file and the value is an array of manifest templates.\n",
-          "type": "array",
-          "items": {
-            "description": "A Kubernetes manifest template.",
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "apiVersion",
-                  "kind"
-                ]
-              },
-              {
-                "type": "string",
-                "pattern": "^\\{\\{.*\\}\\}$"
-              }
-            ]
-          }
-        }
-      },
-      "729fe070-5e67-4bc7-94b5-afd75cb42b03": {
-        "title": "Helm chart template",
-        "type": "object",
-        "required": [
-          "chart",
-          "values"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "chart": {
-            "description": "Path to the Helm chart within the source repo.",
-            "type": "string"
-          },
-          "source": {
-            "description": "Source to pull the Helm chart from.",
-            "type": "string"
-          },
-          "values": {
-            "description": "Helm values to apply. {{Templates}} will be expanded.\n",
-            "type": "object"
-          }
-        }
-      },
-      "88436128-09a3-4c9c-b7f4-b0e495137265": {
-        "title": "Flux HelmRelease manifest template",
-        "type": "object",
-        "required": [
-          "template",
-          "resources"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "template": {
-            "description": "Resource template with {{templates}}",
-            "type": "object",
-            "required": [
-              "apiVersion",
-              "kind"
-            ]
-          },
-          "resources": {
-            "description": "Resource types which represent Helm charts",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "apiVersion",
-                "kind"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "apiVersion": {
-                  "type": "string"
-                },
-                "kind": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
       }
     }
   }

--- a/dumps/edge-deploy-configdb.yaml
+++ b/dumps/edge-deploy-configdb.yaml
@@ -2,7 +2,6 @@ service: !u FP.Service.ConfigDB
 version: 1
 classes:
   - !u E.Class.Cluster
-  - !u E.Class.Template
   # XXX Needed for now
   - !u FP.Class.Service
   - !u FP.Class.PermGroup
@@ -12,7 +11,6 @@ objects:
   !u FP.Class.App:
     - !u E.App.Cluster
     - !u E.App.Status
-    - !u E.App.Flux
     - !u E.App.HelmChart
     - !u E.App.HelmRelease
     # XXX Needed for now
@@ -33,10 +31,8 @@ objects:
 configs:
   !u FP.App.Info:
     !u E.Class.Cluster: { name: "Edge cluster" }
-    !u E.Class.Template: { name: "Edge cluster template" }
     !u E.App.Cluster: { name: "Edge cluster configuration" }
     !u E.App.Status: { name: "Edge cluster setup status" }
-    !u E.App.Flux: { name: "Edge cluster Flux template" }
     !u E.App.HelmChart: { name: "Helm chart template" }
     !u E.App.HelmRelease: { name: "HelmRelease template" }
     !u E.Service.EdgeDeployment: { name: "Edge Deployment Operator" }
@@ -66,58 +62,3 @@ configs:
       type: object
       additionalProperties: true
       # No additional constraints, this is our private data
-    !u E.App.Flux:
-      title: Edge cluster Flux template
-      description: >
-        A template for creating an edge cluster Flux repo. Values that
-        are strings will have {{handlebar}} templates expanded.
-      type: object
-      required: ["self-link.yaml"]
-      additionalProperties:
-        description: >
-          A file to include in the flux repo. The key gives the name of
-          the file and the value is an array of manifest templates.
-        type: array
-        items:
-          description: A Kubernetes manifest template.
-          oneOf:
-            - type: object
-              required: [apiVersion, kind]
-            - type: string
-              pattern: ^\{\{.*\}\}$
-    !u E.App.HelmChart:
-      title: Helm chart template
-      type: object
-      required: [chart, values]
-      additionalProperties: false
-      properties:
-        chart:
-          description: Path to the Helm chart within the source repo.
-          type: string
-        source:
-          description: Source to pull the Helm chart from.
-          type: string
-        values:
-          description: >
-            Helm values to apply. {{Templates}} will be expanded.
-          type: object
-    !u E.App.HelmRelease:
-      title: Flux HelmRelease manifest template
-      type: object
-      required: [template, resources]
-      additionalProperties: false
-      properties:
-        template:
-          description: Resource template with {{templates}}
-          type: object
-          required: [apiVersion, kind]
-        resources:
-          description: Resource types which represent Helm charts
-          type: array
-          items:
-            type: object
-            required: [apiVersion, kind]
-            additionalProperties: false
-            properties:
-              apiVersion: { type: string }
-              kind: { type: string }

--- a/dumps/edge-deploy-configdb.yaml
+++ b/dumps/edge-deploy-configdb.yaml
@@ -57,6 +57,10 @@ configs:
         namespace:
           description: The k8s namespace to deploy to.
           type: string
+        chart:
+          description: The Helm chart to deploy.
+          type: string
+          format: uuid
     !u E.App.Status:
       title: EDO private status
       type: object

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -143,8 +143,13 @@ export class Update extends Action {
         const git = this.fplus.Git;
         const template = this.op.template;
 
+        /* Fetch our cluster helm chart template */
+        const cluster_template = await this.op.config_template(
+            Edge.App.HelmChart,
+            spec.chart ?? this.config.helm.cluster);
+
         /* Build the cluster helm chart template */
-        const cluster = template.cluster({ uuid, name });
+        const cluster = cluster_template({ uuid, name });
         /* Build the cluster HelmRelease manifest */
         const helm = template.helm({ uuid, ...cluster }).template;
         helm.metadata.namespace = spec.namespace;

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -39,13 +39,10 @@ export class Clusters {
             UUIDs.App.ServiceConfig, Edge.Service.EdgeDeployment);
 
         /* XXX We should track changes here, and update the cluster. */
-        const tmpl = (app, obj) => cdb.get_config(app, obj ?? app)
-            .then(t => Template(t));
         this.template = {
-            flux:       await tmpl(Edge.App.Flux),
-            cluster:    await tmpl(Edge.App.HelmChart, this.config.helm.cluster),
-            helm:       await tmpl(Edge.App.HelmRelease),
-            bootstrap:  await tmpl(Edge.App.Bootstrap),
+            flux:       await this.config_template(Edge.App.Flux),
+            helm:       await this.config_template(Edge.App.HelmRelease),
+            bootstrap:  await this.config_template(Edge.App.Bootstrap),
         };
         this.flux_system = await this._init_flux_system();
 
@@ -59,6 +56,12 @@ export class Clusters {
         this.cluster_updates = this._init_cluster_updates(clusters);
 
         return this;
+    }
+
+    async config_template (app, obj) {
+        const { cdb } = this;
+        const conf = await cdb.get_config(app, obj ?? app);
+        return Template(conf);
     }
 
     _init_flux_system () {

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -14,7 +14,6 @@ export const Edge = {
     },
     Class: {
         Cluster:    "f24d354d-abc1-4e32-98e1-0667b3e40b61",
-        Template:   "f9be0334-0ff7-43d3-9d8a-188d3e4d472b",
         Host:       "f24d354d-abc1-4e32-98e1-0667b3e40b61",
         Account:    "97756c9a-38e6-4238-b78c-3df6f227a6c9",
     },


### PR DESCRIPTION
* Move some of the service entries we require into service-setup as they are also required by the edge services.
* Allow a cluster deployment to choose a Helm chart to deploy.