### PR TITLE
Fix bootstrapping problems

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -24,6 +24,7 @@ export class App {
             fplus,
             krbkeys:            env.KRBKEYS_IMAGE,
             realm:              env.REALM,
+            externalDomain:     env.EXTERNAL_DOMAIN,
         });
 
         this.edge = new EdgeDeploy({

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -5,7 +5,9 @@
  */
 
 import crypto from "crypto";
+import process from "process";
 import stream from "stream";
+import timers from "timers/promises";
 
 import Imm      from "immutable";
 import JMP      from "json-merge-patch";
@@ -33,10 +35,7 @@ export class Clusters {
         const { cdb } = this;
         const watcher = await cdb.watcher();
 
-        /* XXX We could track changes here, but this is only updated by
-         * service-setup on ACS upgrade. */
-        this.config = await cdb.get_config(
-            UUIDs.App.ServiceConfig, Edge.Service.EdgeDeployment);
+        await this._init_config(cdb, watcher);
 
         /* XXX We should track changes here, and update the cluster. */
         this.template = {
@@ -62,6 +61,21 @@ export class Clusters {
         const { cdb } = this;
         const conf = await cdb.get_config(app, obj ?? app);
         return Template(conf);
+    }
+
+    async _init_config (cdb, watcher) {
+        /* Exit and restart when service-setup runs */
+        watcher.application(UUIDs.App.ServiceConfig)
+            .subscribe(() => process.exit(0));
+
+        this.config = await cdb.get_config(
+            UUIDs.App.ServiceConfig, Edge.Service.EdgeDeployment);
+
+        /* If we have no SS config, wait 10 minutes and then exit */
+        if (!this.config) {
+            await timers.setTimeout(10*60*1000);
+            process.exit(0);
+        }
     }
 
     _init_flux_system () {

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -22,8 +22,8 @@ export class Clusters {
     constructor (opts) {
         this.fplus      = opts.fplus;
         this.krbkeys    = opts.krbkeys;
-        /* This is used by actions.js */
         this.realm      = opts.realm;
+        this.domain     = opts.externalDomain;
 
         this.log        = this.fplus.debug.bound("edge");
         this.cdb        = this.fplus.ConfigDB;
@@ -182,15 +182,13 @@ export class Clusters {
         const status = await this.cluster_status(uuid);
         if (!status.ready) return null;
 
-        const { namespace, name } = status.spec;
-        const cluster = this.template.cluster({ name, uuid });
+        const { namespace, name }           = status.spec;
+        const { krbkeys, realm, domain }    = this;
         /* We pull values from the edge-cluster Helm chart values. This
          * means we need to stay in sync with that Helm chart. */
         const bootstrap = this.template.bootstrap({
             name, namespace,
-            realm:      cluster.values.krb5.realm,
-            domain:     cluster.values.cluster.domain,
-            krbkeys:    this.krbkeys,
+            domain, realm, krbkeys,
             files:      "@@@@@",
         });
         this.log("Generated bootstrap for %s", uuid);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-clusters",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
* Use values from our environment for generating the bootstrap script instead of trying to unpick the deployed edge cluster Helm chart.
* Restart when service-setup runs.
* Don't fail when service-setup hasn't run yet; this will stop Helm from running it.