### PR TITLE
Check out flux-system for every bootstrap

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,17 +23,17 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.1.1
+        uses: sigstore/cosign-installer@v3.3.0
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
 
@@ -51,7 +51,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -81,7 +81,7 @@ export class Checkout {
          * we commit goes onto the server's default branch. For now
          * assume the default branch is called 'main'. */
         this.log("Creating default branch 'main' for empty repo %s", this.url);
-        git.branch({
+        await git.branch({
             ...this.gitopts,
             ref:        "main",
             checkout:   true,

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -91,7 +91,10 @@ export class Clusters {
         const app = Edge.App.Cluster;
 
         return watcher.application(app).pipe(
-            rx.startWith(undefined),
+            /* Fetch regardless every 10 minutes */
+            rx.mergeWith(rx.timer(0, 10*60*1000).pipe(
+                /* Jitter fetches */
+                rx.delayWhen(() => rx.timer(Math.random() * 5000)))),
             rx.switchMap(() => cdb.list_configs(app)),
             rx.map(cs => Imm.Set(cs)),
         );

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -97,6 +97,7 @@ export class Clusters {
                 rx.delayWhen(() => rx.timer(Math.random() * 5000)))),
             rx.switchMap(() => cdb.list_configs(app)),
             rx.map(cs => Imm.Set(cs)),
+            rx.tap(cs => this.log("CLUSTERS: %o", cs.toJS())),
         );
     }
 

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -44,7 +44,6 @@ export class Clusters {
             helm:       await this.config_template(Edge.App.HelmRelease),
             bootstrap:  await this.config_template(Edge.App.Bootstrap),
         };
-        this.flux_system = await this._init_flux_system();
 
         /* [uuid, patch] requesting status updates */
         this.status_updates = new rx.Subject();
@@ -79,7 +78,7 @@ export class Clusters {
         }
     }
 
-    _init_flux_system () {
+    flux_system () {
         return Checkout.fetch_file({
             fplus:  this.fplus,
             uuid:   this.config.repo.helm.uuid,
@@ -195,7 +194,8 @@ export class Clusters {
 
     async bootstrap (uuid) {
         const status = await this.cluster_status(uuid);
-        if (!status.ready) return null;
+        const flux = await this.flux_system();
+        if (!status.ready || !flux) return null;
 
         const { namespace, name }           = status.spec;
         const { krbkeys, realm, domain }    = this;
@@ -208,7 +208,7 @@ export class Clusters {
         });
         this.log("Generated bootstrap for %s", uuid);
 
-        bootstrap.files["flux-system.yaml"] = this.flux_system;
+        bootstrap.files["flux-system.yaml"] = flux;
         bootstrap.files["self-link.yaml"] = status.self_link;
         
         const marker = crypto.randomBytes(15).toString("base64url");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-cluster-manager",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
We were sometimes ending up with an `undefined` flux-system manifest, because cluster-manager had checked out the repo before git had had a chance to act on its auto-pull instructions. Rather than messing about just check out every time.

Fix a small bug which occurred when checking out an empty repo, and make sure we refresh our cluster list every 10 minutes in case we miss a ConfigDB update.

Fixes: #21
Fixes: #11